### PR TITLE
Remove element explicit height constraint

### DIFF
--- a/JTScrollViewController/JTScrollViewController.m
+++ b/JTScrollViewController/JTScrollViewController.m
@@ -41,7 +41,6 @@
     for(UIView *view in self.contentView.subviews){
         [view mas_remakeConstraints:^(MASConstraintMaker *make) {
             make.left.right.equalTo(view.superview);
-            make.height.equalTo(@(CGRectGetHeight(view.frame)));
         }];
     }
     


### PR DESCRIPTION
Because in some case the element height is defined implicitly, eg by a dynamic height UILabel.
